### PR TITLE
feat: add MIT license to Speakeasy SDK generation

### DIFF
--- a/.speakeasy/workflow.local.yaml
+++ b/.speakeasy/workflow.local.yaml
@@ -1,0 +1,24 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+  GustoEmbedded-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/embedded/api.v2025-06-15.embedded.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+      - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+  GustoAppInt-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/app-integrations/api.v2025-06-15.app-integrations.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-app-int-modifications-overlay.yaml
+      - location: gusto_app_int/.speakeasy/speakeasy-modifications-overlay.yaml
+targets:
+  local:
+    target: python
+    source: GustoEmbedded-local
+    output: ./gusto_embedded
+  local-app-int:
+    target: python
+    source: GustoAppInt-local
+    output: ./gusto_app_int

--- a/gusto_app_int/.speakeasy/gen.yaml
+++ b/gusto_app_int/.speakeasy/gen.yaml
@@ -15,6 +15,10 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
+  license:
+    disabled: false
+    licenseType: MIT
+    companyName: Gusto
 python:
   version: 0.3.0
   additionalDependencies:

--- a/gusto_app_int/.speakeasy/gen.yaml
+++ b/gusto_app_int/.speakeasy/gen.yaml
@@ -15,10 +15,6 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
-  license:
-    disabled: false
-    licenseType: MIT
-    companyName: Gusto
 python:
   version: 0.3.0
   additionalDependencies:
@@ -45,6 +41,7 @@ python:
       shared: ""
       webhooks: ""
   inputModelSuffix: input
+  license: MIT
   maxMethodParams: 999
   methodArguments: infer-optional-args
   outputModelSuffix: output

--- a/gusto_app_int/LICENSE
+++ b/gusto_app_int/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gusto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -18,6 +18,10 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
+  license:
+    disabled: false
+    licenseType: MIT
+    companyName: Gusto
 python:
   version: 0.3.0
   additionalDependencies:

--- a/gusto_embedded/.speakeasy/gen.yaml
+++ b/gusto_embedded/.speakeasy/gen.yaml
@@ -18,10 +18,6 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
-  license:
-    disabled: false
-    licenseType: MIT
-    companyName: Gusto
 python:
   version: 0.3.0
   additionalDependencies:
@@ -49,6 +45,7 @@ python:
       shared: ""
       webhooks: ""
   inputModelSuffix: input
+  license: MIT
   maxMethodParams: 999
   methodArguments: infer-optional-args
   outputModelSuffix: output

--- a/gusto_embedded/LICENSE
+++ b/gusto_embedded/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gusto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds \`python.license: MIT\` to \`gen.yaml\` in both \`gusto_embedded\` and \`gusto_app_int\` — the [correct location](https://www.speakeasy.com/docs/speakeasy-reference/generation/python-config) per Speakeasy docs, which sets the \`license\` field in \`pyproject.toml\`
- Manually adds \`LICENSE\` (MIT) to both \`gusto_embedded/\` and \`gusto_app_int/\`
- Adds \`.speakeasy/workflow.local.yaml\` for running \`speakeasy run --target=local\` during local development

## Test plan

- [x] Confirm \`gusto_embedded/pyproject.toml\` and \`gusto_app_int/pyproject.toml\` have \`license = "MIT"\` after the next \`speakeasy run\`
- [x] Run \`speakeasy run --target=local\` locally and confirm generation succeeds for both targets