### PR TITLE
chore: add local dev setup script and gitignore workflow.local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.speakeasy/workflow.local.yaml

--- a/.speakeasy/workflow.local.example
+++ b/.speakeasy/workflow.local.example
@@ -1,0 +1,31 @@
+# Template for local SDK generation. Copy this file to workflow.local.yaml before use.
+# Intended for Gusto engineers with access to the internal API specification repository.
+# External contributors: local generation requires access to internal Gusto repositories
+# and is not supported outside of Gusto's development environment.
+#
+# Setup: run bin/setup-local to create workflow.local.yaml automatically.
+# Usage: speakeasy run --target=local
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+  GustoEmbedded-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/embedded/api.v2025-06-15.embedded.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-modifications-overlay.yaml
+      - location: gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+  GustoAppInt-local:
+    inputs:
+      - location: ../Gusto-Partner-API/generated/app-integrations/api.v2025-06-15.app-integrations.yaml
+    overlays:
+      - location: ../Gusto-Partner-API/.speakeasy/speakeasy-app-int-modifications-overlay.yaml
+      - location: gusto_app_int/.speakeasy/speakeasy-modifications-overlay.yaml
+targets:
+  local:
+    target: python
+    source: GustoEmbedded-local
+    output: ./gusto_embedded
+  local-app-int:
+    target: python
+    source: GustoAppInt-local
+    output: ./gusto_app_int

--- a/bin/setup-local
+++ b/bin/setup-local
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+DEST=".speakeasy/workflow.local.yaml"
+EXAMPLE=".speakeasy/workflow.local.example"
+
+if [ -f "$DEST" ]; then
+  echo "$DEST already exists — skipping"
+  exit 0
+fi
+
+cp "$EXAMPLE" "$DEST"
+echo "Created $DEST"
+echo ""
+echo "Note: local generation requires access to internal Gusto repositories."
+echo "Run: speakeasy run --target=local"


### PR DESCRIPTION
## Summary

- Adds `.speakeasy/workflow.local.example` as a checked-in template for local SDK generation
- Adds `bin/setup-local` script that copies the example to `workflow.local.yaml` (idempotent)
- Gitignores `.speakeasy/workflow.local.yaml` so it is never accidentally committed

## Why

`workflow.local.yaml` being committed was breaking the Speakeasy CI pipeline — the SDK generation action picks up that exact filename and uses it in place of the production workflow config. The `.example` filename is safe and ignored by the pipeline.

## Test plan

- [x] `bin/setup-local` creates `.speakeasy/workflow.local.yaml` from the example
- [x] Re-running `bin/setup-local` is a no-op (skips if file exists)
- [x] `.speakeasy/workflow.local.yaml` does not appear as a staged file after running setup
- [ ] Speakeasy CI pipeline runs without interference from local config