### PR TITLE
fix: extend zip rename overlay to component schemas

### DIFF
--- a/gusto_app_int/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/gusto_app_int/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -8,6 +8,16 @@ info:
     before: ""
     type: speakeasy-modifications
 actions:
+  # Rename the `zip` postal-code property to `zip_code` so the generated
+  # Python SDK doesn't shadow the `zip()` builtin (pylint W0622 fails the
+  # Compile SDK step). The original rule only matched inline schemas under
+  # `paths`; many address schemas live under `components.schemas` and are
+  # referenced via $ref, so we also need to rewrite the property there.
+  # Both rules together cover every `zip` postal-code property the spec
+  # exposes.
   - target: $.paths..schema..zip
+    update:
+      x-speakeasy-name-override: zip_code
+  - target: $.components.schemas..properties.zip
     update:
       x-speakeasy-name-override: zip_code

--- a/gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/gusto_embedded/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -8,6 +8,16 @@ info:
     before: ""
     type: speakeasy-modifications
 actions:
+  # Rename the `zip` postal-code property to `zip_code` so the generated
+  # Python SDK doesn't shadow the `zip()` builtin (pylint W0622 fails the
+  # Compile SDK step). The original rule only matched inline schemas under
+  # `paths`; many address schemas live under `components.schemas` and are
+  # referenced via $ref, so we also need to rewrite the property there.
+  # Both rules together cover every `zip` postal-code property the spec
+  # exposes.
   - target: $.paths..schema..zip
+    update:
+      x-speakeasy-name-override: zip_code
+  - target: $.components.schemas..properties.zip
     update:
       x-speakeasy-name-override: zip_code


### PR DESCRIPTION
## Summary
The existing zip→zip_code rename overlay only matches `zip` properties that appear in **inline** schemas under `paths`. Many address schemas (e.g., `Location`, `Contractor-Address`) live under `components.schemas` and are referenced via `\$ref` from path operations — those zip occurrences never get renamed.

Newly generated method signatures that go through `\$ref`'d component schemas end up with bare \`zip\` parameters, which shadow Python's \`zip()\` builtin. Pylint W0622 then fails the **Compile SDK** step:

\`\`\`
src/gusto_embedded/locations.py:251:8: W0622: Redefining built-in 'zip' (redefined-builtin)
src/gusto_embedded/locations.py:402:8: W0622: Redefining built-in 'zip' (redefined-builtin)
src/gusto_embedded/contractors.py:2181:8: W0622: Redefining built-in 'zip' (redefined-builtin)
src/gusto_embedded/contractors.py:2323:8: W0622: Redefining built-in 'zip' (redefined-builtin)
\`\`\`

(Most recent failure: [run #26044020966](https://github.com/Gusto/gusto-python-client/actions/runs/26044020966).)

## Change
Adds a second overlay rule targeting \`\$.components.schemas..properties.zip\` so the rename covers every \`zip\` postal-code property the spec exposes, regardless of whether it's inlined or \$ref'd. Applied to both the \`gusto_embedded\` and \`gusto_app_int\` overlays since they share the same gap.

## Test plan
- [ ] Trigger the Generate workflow on this branch and confirm the Compile SDK step passes (no \`redefined-builtin 'zip'\` warnings)
- [ ] Spot-check that generated method signatures using ref'd address schemas (e.g., \`contractors.update_address\`, \`locations.create\`) use \`zip_code\` instead of \`zip\`
- [ ] Confirm no other Speakeasy lint regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)